### PR TITLE
pushdocs: use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/pushdocs.yml
+++ b/.github/workflows/pushdocs.yml
@@ -27,5 +27,5 @@ jobs:
       run: |
         scripts/push-docs
       env:
-        GITHUB_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Actions provides a token automatically, there was no need to
create a separate token.